### PR TITLE
Add README with deprecation notice to the gh_pages branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+**DEPRECATION NOTICE**
+
+ChartboostCoreSDK documentation on GitHub pages has been deprecated.
+ 
+For the latest docs go to https://reference.chartboost.com/core/ios/


### PR DESCRIPTION
Publishes Core versions link to the existing gh pages docs in their podspecs and readme. I think it's a good idea to leave this branch alive for now, but adding this deprecation notice might prevent confusion.