### PR TITLE
Update ChartboostCoreSDK.podspec (#12)

### DIFF
--- a/ChartboostCoreSDK.podspec
+++ b/ChartboostCoreSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostCoreSDK'
-  spec.version     = '0.2.0'
+  spec.version     = '0.3.0'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-core-ios-sdk'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }


### PR DESCRIPTION
Version was outdated due to a CI issue.
Fixing manually here.